### PR TITLE
Refactor `*User* to User struct

### DIFF
--- a/couch/models/user.go
+++ b/couch/models/user.go
@@ -39,8 +39,8 @@ func GetUser(name string) (*User, error) {
   return ret, err
 }
 
-func CreateUser(user *User, password string) error {
-  ph := pbkdf2.HashPassword(password)
+func (user *User) Create() error {
+  ph := pbkdf2.HashPassword(user.Pass)
 
   user.Salt = string(ph.Salt)
   user.Pass = string(ph.Hash)
@@ -56,20 +56,20 @@ func CreateUser(user *User, password string) error {
   return err
 }
 
-func DeleteUser(name string) error {
-  user, err := GetUser(name)
-  if err != nil {
-    return err
-  }
-
-  _, err = couch.Global.Delete(prefix + user.Username, user.Rev)
+func (user *User) Delete() error {
+  _, err := couch.Global.Delete(prefix + user.Username, user.Rev)
   return err
 }
 
-func AuthUser(name string, pass string) bool {
-  ret, err := GetUser(name)
-  if err != nil { return false }
-  ph := &pbkdf2.PasswordHash{[]byte(ret.Pass), []byte(ret.Salt)}
+func (user *User) MatchPassword(pass string) bool {
+  ph := &pbkdf2.PasswordHash{[]byte(user.Pass), []byte(user.Salt)}
   return pbkdf2.MatchPassword(pass, ph)
 }
 
+func AuthUser(user string, pass string) bool {
+  ret, err := GetUser(user)
+  if (err != nil) {
+    return false;
+  }
+  return ret.MatchPassword(pass)
+}

--- a/couch/models/user_test.go
+++ b/couch/models/user_test.go
@@ -7,31 +7,38 @@ import (
 
 var (
   username = "foo"
+  email = "foo@bar.com"
+  pass = "4321"
   user = &User{
     Username: username,
+    Email: email,
+    Pass: pass,
   }
 )
 
 func TestUserCreate(t *testing.T) {
-  err := CreateUser(user)
+  err := user.Create()
   assert.Nil(t, err, "Error should be `nil`")
 }
 
 func TestUserAlreadyExists(t *testing.T) {
-  err := CreateUser(user)
+  err := user.Create()
   assert.NotNil(t, err, "Error should not be `nil`")
-  assert.IsType(t, err, AlreadyExistsError{})
+  assert.IsType(t, AlreadyExistsError{}, err)
 }
 
 func TestUserGet(t *testing.T) {
   getUser, getError := GetUser(username)
   assert.Nil(t, getError, "Get error should be `nil`")
+  assert.True(t, getUser.MatchPassword(pass), "Password should match")
   assert.Equal(t, getUser.Username, username)
 }
 
 func TestUserDelete(t *testing.T) {
-  err := DeleteUser(username)
-  assert.Nil(t, err, "Delete error should be `nil`")  
+  user, err := GetUser(username)
+  assert.Nil(t, err, "Get error should be `nil`")
+  err = user.Delete()
+  assert.Nil(t, err, "Delete error should be `nil`")
 }
 
 func TestNoSuchUser(t *testing.T) {

--- a/user.go
+++ b/user.go
@@ -22,8 +22,9 @@ func CreateUser(req *f.Request, res *f.Response, next func()) {
 
     u.Username = username
     u.Email = email
+    u.Pass = password
 
-    e := models.CreateUser(u, password)
+    e := u.Create()
     if (e != nil) {
       // @TODO: Don't just send the whole error here
       res.Send(e, 400)


### PR DESCRIPTION
Also add some tests for User.

@AvianFlu right now `assert.True(t, getUser.MatchPassword(pass), "Password should match")` fails (in `user_test.go`). Do you have any idea as to why it happens? When I try to `Printf` the hash we get it isn't human-readable. Do we need to encode it as hex?
